### PR TITLE
Fix thin white line on downloaded banner

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ randomize();
 const download = () => {
   html2canvas(capture, {
     scale: 1.5,
+    backgroundColor: getComputedStyle(document.documentElement).getPropertyValue("--bg-color")
   }).then((canvas) => {
     saveAs(canvas.toDataURL(), "banner.png");
   });


### PR DESCRIPTION
This pull request fixes #4 issue. 

A bit of a crutch way to fix it. But it works.